### PR TITLE
Replace `.notebook` with `.laptop`

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@
 
 `tablet` — планшеты
 
-`notebook` — ноутбуки
+`notebook`, `laptop` — ноутбуки
 
 `desktop` — настольные компьютеры
 


### PR DESCRIPTION
The English word "notebook" is only used in Russian-speaking countries, whereas native English speakers refer to these devices as "laptops", so we'd better stick with the latter.